### PR TITLE
add alternative size and checksums fields to ingest daemon check

### DIFF
--- a/Mover.py
+++ b/Mover.py
@@ -95,7 +95,7 @@ class FileMoverTask(Task, Logged):
         
         try:    
             metadata = json.loads(json_text)
-            if "file_size" not in metadata or "checksum" not in metadata:
+            if ("file_size" not in metadata and "size" not in metadata) or ("checksum" not in metadata and "checksums" not in metadata):
                 return self.failed("metadata does not include size or checksum")
         except: 
             self.log_record("metadata parsing error: %s" % (traceback.format_exc(),))


### PR DESCRIPTION
Cloning from ivmfnal/protodune, pull request from @StevenCTimm

new metadata has size: and checksums: field instead of file_size: and checksum: